### PR TITLE
fix(package.json): invalid main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generators",
     "common"
   ],
-  "main": "generators/index.js",
+  "main": "generators/app/index.js",
   "keywords": [
     "svelte",
     "svelte.js",


### PR DESCRIPTION
Hey, I was using your lovely generator as a sub generator to something I'm building. When attempting to invoke the sub generator I noticed your package.json main was pointing to a non existant file.